### PR TITLE
リクルートのリンク先URLを変更

### DIFF
--- a/source/posts/2024-08-13-57th-general.html.md
+++ b/source/posts/2024-08-13-57th-general.html.md
@@ -195,7 +195,7 @@ containerdサブプロジェクトであるnerdctlや、CNCFプロジェクト�
 
 [51th]: assets/images/51th_general_group.jpg
 
-[recruit_link]: https://blog.recruit.co.jp/data/
+[recruit_link]: https://techblog.recruit.co.jp/
 [recruit_logo]: assets/images/Recruit_Holdings_logo.png
 
 [lycorp_link]: https://www.lycorp.co.jp/ja/technology/


### PR DESCRIPTION
### 概要
[参加者募集ページ](https://wakate.org/2024/08/13/57th-general/)のスポンサー欄にある、リクルートのロゴのリンク先を https://techblog.recruit.co.jp/ に変更しました。
